### PR TITLE
Fixed variable naming conflicts

### DIFF
--- a/SellSword.lua
+++ b/SellSword.lua
@@ -16,7 +16,9 @@
 -- You should have received a copy of the GNU General Public License
 -- along with SellSword.  If not, see <http://www.gnu.org/licenses/>.
 
-
+function SellSword_OnLoad()
+  -- Do Stuff
+end
 
 -- Scanner
 -- function satchelFinder(id)

--- a/SellSword.xml
+++ b/SellSword.xml
@@ -3,7 +3,7 @@
   <Scripts>
     <OnLoad>
       SellSword_OnLoad(self);
-	  self.TimeSinceLastUpdate = 0
+	    self.TimeSinceLastUpdate = 0
     </OnLoad>
 	<OnUpdate function="SellSword_OnUpdate"/>
   </Scripts>

--- a/SellSword_Options.lua
+++ b/SellSword_Options.lua
@@ -16,9 +16,10 @@
 -- You should have received a copy of the GNU General Public License
 -- along with SellSword.  If not, see <http://www.gnu.org/licenses/>.
 
+local sso = {}
 local checkboxes = {}
 
-local function addSubCategory(parent, name)
+function sso.addSubCategory(parent, name)
 	local header = parent:CreateFontString(nil, "ARTWORK", "GameFontHighlightSmall")
 	header:SetText(name)
 
@@ -30,89 +31,90 @@ local function addSubCategory(parent, name)
 	return header
 end
 
-local function toggle(f)
-	SatchelScannerConfig[f.value] = f:GetChecked()
+function sso.toggle(f)
+	SellSwordConfig[f.value] = f:GetChecked()
 end
 
-local function createToggleBox(parent, value, text)
+function sso.createToggleBox(parent, value, text)
 	local f = CreateFrame("CheckButton", nil, parent, "InterfaceOptionsCheckButtonTemplate")
 	f.value = value
 
 	f.Text:SetText(text)
 
-	f:SetScript("OnClick", toggle)
+	f:SetScript("OnClick", sso.toggle)
 
 	tinsert(checkboxes, f)
 
 	return f
 end
 
-local SatchelOptions = CreateFrame("Frame", "SatchelOptions", UIParent)
-SatchelOptions.name = "Satchel"
-InterfaceOptions_AddCategory(SatchelOptions)
+local SellSwordOptions = CreateFrame("Frame", "SellSwordOptions", UIParent)
+SellSwordOptions.name = "SellSword"
+InterfaceOptions_AddCategory(SellSwordOptions)
 
-local title = SatchelOptions:CreateFontString(nil, "ARTWORK", "GameFontNormalLarge")
-title:SetPoint("TOP", 0, -26)
-title:SetText("Satchel Scanner "..GetAddOnMetadata("SatchelScanner", "Version"))
+local title = SellSwordOptions:CreateFontString(nil, "ARTWORK", "GameFontNormalLarge")
+title:SetPoint("TOP", -90, -26)
+title:SetText("SellSword "..GetAddOnMetadata("SellSword", "Version"))
 
-local features = addSubCategory(SatchelOptions, "Features")
+local features = sso.addSubCategory(SellSwordOptions, "Features")
 features:SetPoint("TOPLEFT", 16, -80)
 
-local autoStartBox = createToggleBox(SatchelOptions, "autoStart", "Auto Start")
+local autoStartBox = sso.createToggleBox(SellSwordOptions, "autoStart", "Auto Start")
 autoStartBox:SetPoint("TOPLEFT", features, "BOTTOMLEFT", 0, -20)
 
-local intervalTimerSlider = CreateFrame("Slider", "intervalTimer", SatchelOptions, "OptionsSliderTemplate")
-local intervalTimerText2 = SatchelOptions:CreateFontString(nil, "ARTWORK", "GameFontHighlight")
+local intervalTimerSlider = CreateFrame("Slider", "intervalTimer", SellSwordOptions, "OptionsSliderTemplate")
+local intervalTimerValueText = SellSwordOptions:CreateFontString(nil, "ARTWORK", "GameFontHighlight")
 intervalTimerSlider:SetPoint("LEFT", autoStartBox, "RIGHT", 195, 0)
 BlizzardOptionsPanel_Slider_Enable(intervalTimerSlider)
 intervalTimerSlider:SetMinMaxValues(1,10)
 intervalTimerSlider:SetValueStep(1)
+intervalTimerSlider:SetObeyStepOnDrag(true)
 intervalTimerText:SetText("Interval to Scan (in seconds)")
-intervalTimerText2:SetPoint("LEFT", intervalTimerSlider, "RIGHT", 10, 0)
-intervalTimerSlider:SetScript("OnValueChanged", function(self) intervalTimerText2:SetText(intervalTimerSlider:GetValue()) end)
+intervalTimerValueText:SetPoint("LEFT", intervalTimerSlider, "RIGHT", 10, 0)
+intervalTimerSlider:SetScript("OnValueChanged", function(self) intervalTimerValueText:SetText(intervalTimerSlider:GetValue()) end)
 
-local raidWarnBox = createToggleBox(SatchelOptions, "raidWarn", "Play Raid Warnings")
+local raidWarnBox = sso.createToggleBox(SellSwordOptions, "raidWarn", "Play Raid Warnings")
 raidWarnBox:SetPoint("TOPLEFT", autoStartBox, "BOTTOMLEFT", 0, -8)
 
-local soundWarnBox = createToggleBox(SatchelOptions, "soundWarn", "Play Sound Warnings")
+local soundWarnBox = sso.createToggleBox(SellSwordOptions, "soundWarn", "Play Sound Warnings")
 soundWarnBox:SetPoint("LEFT", raidWarnBox, "RIGHT", 180, 0)
 
-local queueTypes = addSubCategory(SatchelOptions, "Queue Types")
+local queueTypes = sso.addSubCategory(SellSwordOptions, "Queue Types")
 queueTypes:SetPoint("TOPLEFT", raidWarnBox, "BOTTOMLEFT", 0, -30)
 
-local scanForTankBox = createToggleBox(SatchelOptions, "scanForTanks", "Scan for Tank Satchels")
+local scanForTankBox = sso.createToggleBox(SellSwordOptions, "scanForTanks", "Scan Tank Queues")
 scanForTankBox:SetPoint("TOPLEFT", queueTypes, "BOTTOMLEFT", 0, -20)
 
-local scanForHealBox = createToggleBox(SatchelOptions, "scanForHeal", "Scan for Healer Satchels")
+local scanForHealBox = sso.createToggleBox(SellSwordOptions, "scanForHeal", "Scan Healer Queues")
 scanForHealBox:SetPoint("LEFT", scanForTankBox, "Right", 180, 0)
 
-local scanForDPSBox = createToggleBox(SatchelOptions, "scanForDPS", "Scan for DPS Satchels")
+local scanForDPSBox = sso.createToggleBox(SellSwordOptions, "scanForDPS", "Scan DPS Queues")
 scanForDPSBox:SetPoint("TOPLEFT", scanForTankBox, "BOTTOMLEFT", 0, -8)
 
-local dungeonTypes = addSubCategory(SatchelOptions, "Dungeon Types")
+local dungeonTypes = sso.addSubCategory(SellSwordOptions, "Dungeon Types")
 dungeonTypes:SetPoint("TOPLEFT", scanForDPSBox, "BOTTOMLEFT", 0, -30)
 
-local scanForWoDBox = createToggleBox(SatchelOptions, "scanForWoD", "Scan for WoD Heroics")
+local scanForWoDBox = sso.createToggleBox(SellSwordOptions, "scanForWoD", "Scan WoD Heroics")
 scanForWoDBox:SetPoint("TOPLEFT", dungeonTypes, "BOTTOMLEFT", 0, -20)
 
-local scanForTWBox = createToggleBox(SatchelOptions, "scanForTW", "Scan for TimeWalking")
+local scanForTWBox = sso.createToggleBox(SellSwordOptions, "scanForTW", "Scan TimeWalking")
 scanForTWBox:SetPoint("LEFT", scanForWoDBox, "Right", 180, 0)
 
-local scanForLFRBox = createToggleBox(SatchelOptions, "scanForLFR", "Scan for Looking for Raid")
+local scanForLFRBox = sso.createToggleBox(SellSwordOptions, "scanForLFR", "Scan Looking for Raid")
 scanForLFRBox:SetPoint("TOPLEFT", scanForWoDBox, "BOTTOMLEFT", 0, -8)
 
-local credits = SatchelOptions:CreateFontString(nil, "ARTWORK", "GameFontHighlight")
-credits:SetText("Satchel Scanner by joypunk aka Seintefie / US-Thrall")
-credits:SetPoint("BOTTOM", 0, 40)
+local credits = SellSwordOptions:CreateFontString(nil, "ARTWORK", "GameFontHighlight")
+credits:SetText("SellSword by joypunk aka Seintefie / US-Thrall")
+credits:SetPoint("BOTTOM", -80, 40)
 
-SatchelOptions:RegisterEvent("ADDON_LOADED")
-SatchelOptions:SetScript("OnEvent", function(self, _, addon)
-	if addon ~= "SatchelScanner" then return end
-
-		self:UnregisterEvent("ADDON_LOADED")
+SellSwordOptions:RegisterEvent("ADDON_LOADED")
+SellSwordOptions:SetScript("OnEvent", function(self, _, addon)
+	if addon ~= "SellSword" then return end
+	self:UnregisterEvent("ADDON_LOADED")
 end)
 
-SlashCmdList.SatchelScanner = function()
-	InterfaceOptionsFrame_OpenToCategory(SatchelOptions)
+SlashCmdList.SellSword = function()
+	InterfaceOptionsFrame_OpenToCategory(SellSwordOptions)
 end
-SLASH_SatchelScanner1 = "/satchel"
+SLASH_SellSword1 = "/SellSword"
+SLASH_SellSword2 = "/ss"

--- a/SellSword_Options.lua
+++ b/SellSword_Options.lua
@@ -16,10 +16,9 @@
 -- You should have received a copy of the GNU General Public License
 -- along with SellSword.  If not, see <http://www.gnu.org/licenses/>.
 
-local sso = {}
 local checkboxes = {}
 
-function sso.addSubCategory(parent, name)
+local function addSubCategory(parent, name)
 	local header = parent:CreateFontString(nil, "ARTWORK", "GameFontHighlightSmall")
 	header:SetText(name)
 
@@ -31,17 +30,17 @@ function sso.addSubCategory(parent, name)
 	return header
 end
 
-function sso.toggle(f)
+local function toggle(f)
 	SellSwordConfig[f.value] = f:GetChecked()
 end
 
-function sso.createToggleBox(parent, value, text)
+local function createToggleBox(parent, value, text)
 	local f = CreateFrame("CheckButton", nil, parent, "InterfaceOptionsCheckButtonTemplate")
 	f.value = value
 
 	f.Text:SetText(text)
 
-	f:SetScript("OnClick", sso.toggle)
+	f:SetScript("OnClick", toggle)
 
 	tinsert(checkboxes, f)
 
@@ -56,51 +55,51 @@ local title = SellSwordOptions:CreateFontString(nil, "ARTWORK", "GameFontNormalL
 title:SetPoint("TOP", -90, -26)
 title:SetText("SellSword "..GetAddOnMetadata("SellSword", "Version"))
 
-local features = sso.addSubCategory(SellSwordOptions, "Features")
+local features = addSubCategory(SellSwordOptions, "Features")
 features:SetPoint("TOPLEFT", 16, -80)
 
-local autoStartBox = sso.createToggleBox(SellSwordOptions, "autoStart", "Auto Start")
+local autoStartBox = createToggleBox(SellSwordOptions, "sso_autoStart", "Auto Start")
 autoStartBox:SetPoint("TOPLEFT", features, "BOTTOMLEFT", 0, -20)
 
-local intervalTimerSlider = CreateFrame("Slider", "intervalTimer", SellSwordOptions, "OptionsSliderTemplate")
+local intervalTimerSlider = CreateFrame("Slider", "sso_intervalTimer", SellSwordOptions, "OptionsSliderTemplate")
 local intervalTimerValueText = SellSwordOptions:CreateFontString(nil, "ARTWORK", "GameFontHighlight")
 intervalTimerSlider:SetPoint("LEFT", autoStartBox, "RIGHT", 195, 0)
 BlizzardOptionsPanel_Slider_Enable(intervalTimerSlider)
 intervalTimerSlider:SetMinMaxValues(1,10)
 intervalTimerSlider:SetValueStep(1)
 intervalTimerSlider:SetObeyStepOnDrag(true)
-intervalTimerText:SetText("Interval to Scan (in seconds)")
+sso_intervalTimerText:SetText("Interval to Scan (in seconds)")
 intervalTimerValueText:SetPoint("LEFT", intervalTimerSlider, "RIGHT", 10, 0)
 intervalTimerSlider:SetScript("OnValueChanged", function(self) intervalTimerValueText:SetText(intervalTimerSlider:GetValue()) end)
 
-local raidWarnBox = sso.createToggleBox(SellSwordOptions, "raidWarn", "Play Raid Warnings")
+local raidWarnBox = createToggleBox(SellSwordOptions, "sso_raidWarn", "Play Raid Warnings")
 raidWarnBox:SetPoint("TOPLEFT", autoStartBox, "BOTTOMLEFT", 0, -8)
 
-local soundWarnBox = sso.createToggleBox(SellSwordOptions, "soundWarn", "Play Sound Warnings")
+local soundWarnBox = createToggleBox(SellSwordOptions, "sso_soundWarn", "Play Sound Warnings")
 soundWarnBox:SetPoint("LEFT", raidWarnBox, "RIGHT", 180, 0)
 
-local queueTypes = sso.addSubCategory(SellSwordOptions, "Queue Types")
+local queueTypes = addSubCategory(SellSwordOptions, "Queue Types")
 queueTypes:SetPoint("TOPLEFT", raidWarnBox, "BOTTOMLEFT", 0, -30)
 
-local scanForTankBox = sso.createToggleBox(SellSwordOptions, "scanForTanks", "Scan Tank Queues")
+local scanForTankBox = createToggleBox(SellSwordOptions, "sso_scanForTanks", "Scan Tank Queues")
 scanForTankBox:SetPoint("TOPLEFT", queueTypes, "BOTTOMLEFT", 0, -20)
 
-local scanForHealBox = sso.createToggleBox(SellSwordOptions, "scanForHeal", "Scan Healer Queues")
+local scanForHealBox = createToggleBox(SellSwordOptions, "sso_scanForHeal", "Scan Healer Queues")
 scanForHealBox:SetPoint("LEFT", scanForTankBox, "Right", 180, 0)
 
-local scanForDPSBox = sso.createToggleBox(SellSwordOptions, "scanForDPS", "Scan DPS Queues")
+local scanForDPSBox = createToggleBox(SellSwordOptions, "sso_scanForDPS", "Scan DPS Queues")
 scanForDPSBox:SetPoint("TOPLEFT", scanForTankBox, "BOTTOMLEFT", 0, -8)
 
-local dungeonTypes = sso.addSubCategory(SellSwordOptions, "Dungeon Types")
+local dungeonTypes = addSubCategory(SellSwordOptions, "Dungeon Types")
 dungeonTypes:SetPoint("TOPLEFT", scanForDPSBox, "BOTTOMLEFT", 0, -30)
 
-local scanForWoDBox = sso.createToggleBox(SellSwordOptions, "scanForWoD", "Scan WoD Heroics")
+local scanForWoDBox = createToggleBox(SellSwordOptions, "sso_scanForWoD", "Scan WoD Heroics")
 scanForWoDBox:SetPoint("TOPLEFT", dungeonTypes, "BOTTOMLEFT", 0, -20)
 
-local scanForTWBox = sso.createToggleBox(SellSwordOptions, "scanForTW", "Scan TimeWalking")
+local scanForTWBox = createToggleBox(SellSwordOptions, "sso_scanForTW", "Scan TimeWalking")
 scanForTWBox:SetPoint("LEFT", scanForWoDBox, "Right", 180, 0)
 
-local scanForLFRBox = sso.createToggleBox(SellSwordOptions, "scanForLFR", "Scan Looking for Raid")
+local scanForLFRBox = createToggleBox(SellSwordOptions, "sso_scanForLFR", "Scan Looking for Raid")
 scanForLFRBox:SetPoint("TOPLEFT", scanForWoDBox, "BOTTOMLEFT", 0, -8)
 
 local credits = SellSwordOptions:CreateFontString(nil, "ARTWORK", "GameFontHighlight")


### PR DESCRIPTION
Using the Blizz API to create variables makes them global, so poorly named variables will conflict with other addons using the same name.
